### PR TITLE
Don't require DONT_PAIR

### DIFF
--- a/secret_santa.py
+++ b/secret_santa.py
@@ -11,8 +11,6 @@ import sys
 import getopt
 import os
 
-import traceback as tb
-
 help_message = '''
 To use, fill out config.yml with your own participants. You can also specify 
 DONT-PAIR so that people don't get assigned their significant other.

--- a/secret_santa.py
+++ b/secret_santa.py
@@ -11,6 +11,8 @@ import sys
 import getopt
 import os
 
+import traceback as tb
+
 help_message = '''
 To use, fill out config.yml with your own participants. You can also specify 
 DONT-PAIR so that people don't get assigned their significant other.
@@ -28,7 +30,6 @@ REQRD = (
     'PASSWORD', 
     'TIMEZONE', 
     'PARTICIPANTS', 
-    'DONT-PAIR', 
     'FROM', 
     'SUBJECT', 
     'MESSAGE',
@@ -117,7 +118,12 @@ def main(argv=None):
                     'Required parameter %s not in yaml config file!' % (key,))
 
         participants = config['PARTICIPANTS']
-        dont_pair = config['DONT-PAIR']
+
+        try:
+            dont_pair = config['DONT-PAIR']
+        except KeyError, TypeError:
+            dont_pair = []
+
         if len(participants) < 2:
             raise Exception('Not enough participants specified.')
         

--- a/secret_santa.py
+++ b/secret_santa.py
@@ -55,34 +55,34 @@ class Person:
         return "%s <%s>" % (self.name, self.email)
 
 class Pair:
-    def __init__(self, giver, reciever):
+    def __init__(self, giver, receiver):
         self.giver = giver
-        self.reciever = reciever
+        self.receiver = receiver
     
     def __str__(self):
-        return "%s ---> %s" % (self.giver.name, self.reciever.name)
+        return "%s ---> %s" % (self.giver.name, self.receiver.name)
 
 def parse_yaml(yaml_path=CONFIG_PATH):
     return yaml.load(open(yaml_path))    
 
-def choose_reciever(giver, recievers):
-    choice = random.choice(recievers)
+def choose_receiver(giver, receivers):
+    choice = random.choice(receivers)
     if choice.name in giver.invalid_matches or giver.name == choice.name:
-        if len(recievers) is 1:
-            raise Exception('Only one reciever left, try again')
-        return choose_reciever(giver, recievers)
+        if len(receivers) is 1:
+            raise Exception('Only one receiver left, try again')
+        return choose_receiver(giver, receivers)
     else:
         return choice
 
 def create_pairs(g, r):
     givers = g[:]
-    recievers = r[:]
+    receivers = r[:]
     pairs = []
     for giver in givers:
         try:
-            reciever = choose_reciever(giver, recievers)
-            recievers.remove(reciever)
-            pairs.append(Pair(giver, reciever))
+            receiver = choose_receiver(giver, receivers)
+            receivers.remove(receiver)
+            pairs.append(Pair(giver, receiver))
         except:
             return create_pairs(g, r)
     return pairs
@@ -136,8 +136,8 @@ def main(argv=None):
             person = Person(name, email, invalid_matches)
             givers.append(person)
         
-        recievers = givers[:]
-        pairs = create_pairs(givers, recievers)
+        receivers = givers[:]
+        pairs = create_pairs(givers, receivers)
         if not send:
             print """
 Test pairings:
@@ -162,7 +162,7 @@ call with the --send argument:
             message_id = '<%s@%s>' % (str(time.time())+str(random.random()), socket.gethostname())
             frm = config['FROM']
             to = pair.giver.email
-            subject = config['SUBJECT'].format(santa=pair.giver.name, santee=pair.reciever.name)
+            subject = config['SUBJECT'].format(santa=pair.giver.name, santee=pair.receiver.name)
             body = (HEADER+config['MESSAGE']).format(
                 date=date, 
                 message_id=message_id, 
@@ -170,7 +170,7 @@ call with the --send argument:
                 to=to, 
                 subject=subject,
                 santa=pair.giver.name,
-                santee=pair.reciever.name,
+                santee=pair.receiver.name,
             )
             if send:
                 result = server.sendmail(frm, [to], body)


### PR DESCRIPTION
I had a case where I didn't have any "don't pair" options specified (where gifts go to couples, not to individuals). So I made DONT_PAIR optional.
